### PR TITLE
Add Bootstrap3 support and organize SASS structure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,17 +6,15 @@ gem 'rails', '4.0.1'
 # Use postgresql as the database for Active Record
 gem 'pg'
 
-# Use SCSS for stylesheets
-gem 'sass-rails', '~> 4.0.0'
+# Use Bootstrap/SCSS for stylesheets
+gem 'bootstrap-sass', '~> 3.3.5'
+gem 'sass-rails',     '~> 4.0.0'
 
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 
 # Use CoffeeScript for .js.coffee assets and views
 gem 'coffee-rails', '~> 4.0.0'
-
-# See https://github.com/sstephenson/execjs#readme for more supported runtimes
-# gem 'therubyracer', platforms: :ruby
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
@@ -32,16 +30,5 @@ group :doc do
   gem 'sdoc', require: false
 end
 
+# Use Simple Form for easier form generation
 gem 'simple_form', '~> 3.2'
-
-# Use ActiveModel has_secure_password
-# gem 'bcrypt-ruby', '~> 3.1.2'
-
-# Use unicorn as the app server
-# gem 'unicorn'
-
-# Use Capistrano for deployment
-# gem 'capistrano', group: :development
-
-# Use debugger
-# gem 'debugger', group: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,12 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
     arel (4.0.2)
+    autoprefixer-rails (6.0.3)
+      execjs
+      json
+    bootstrap-sass (3.3.5)
+      autoprefixer-rails (>= 5.0.0.1)
+      sass (>= 3.2.19)
     builder (3.1.4)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
@@ -110,6 +116,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bootstrap-sass (~> 3.3.5)
   coffee-rails (~> 4.0.0)
   jbuilder (~> 1.2)
   jquery-rails
@@ -120,6 +127,3 @@ DEPENDENCIES
   simple_form (~> 3.2)
   turbolinks
   uglifier (>= 1.3.0)
-
-BUNDLED WITH
-   1.10.6

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,5 +9,5 @@
  * compiled file, but it's generally better to create a new file per style scope.
  *
  *= require_self
- *= require_tree .
+ *= require main
  */

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -1,0 +1,8 @@
+
+// Apply any global variable overrides then import Bootstrap 3
+@import "modules/bootstrap-overrides";
+@import "modules/bootstrap-framework";
+
+// Import modules that should be globally available
+
+// Lastly import partials

--- a/app/assets/stylesheets/modules/_bootstrap-framework.scss
+++ b/app/assets/stylesheets/modules/_bootstrap-framework.scss
@@ -1,0 +1,2 @@
+@import "bootstrap-sprockets";
+@import "bootstrap";

--- a/app/assets/stylesheets/modules/_bootstrap-overrides.scss
+++ b/app/assets/stylesheets/modules/_bootstrap-overrides.scss
@@ -1,0 +1,3 @@
+
+// Main color palette
+$brand-primary: navy;

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -1,2 +1,2 @@
-<h1>Future home of the best chess game ever made...</h1>
+<h1 class="text-primary">Future home of the best chess game ever made...</h1>
 <a href="https://github.com/KnightsOfTheRemoteTable/chess_app">Github</a>


### PR DESCRIPTION
So, I've actually done two things here but they make sense as one commit. First, I have added in Bootstrap support. Secondly, I've re-configured the stylesheets directory a bit to conform with something I think will be a bit more DRY. Instead of having stylesheet files created on a per-controller basis, we can write the code once and organize it more sensibly. Take a look here for some good information: http://thesassway.com/beginner/how-to-structure-a-sass-project - application-wide code will go in the modules sub-folder and more one-off pieces of CSS (that make the navbar work, for instance) can go in the partials sub-folder. All modules and partials are imported by `main.scss`, which makes that file very easy to reason about and makes `application.scss` very simple as all it has to do is require `main.scss`.

The only other issue of note I think is that, to override Bootstrap variables (all of which are available here in SASS - https://github.com/twbs/bootstrap-sass/blob/master/assets/stylesheets/bootstrap/_variables.scss - you need to import them before you import Bootstrap itself, which is why `main.scss` first imports any overrides and then imports the framework. Let me know if that is not clear or if the approach to stylesheet assets is not something you are familiar/comfortable/happy with...

:smile: 