### PR TITLE
Setup initial chessboard view

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -6,3 +6,4 @@
 // Import modules that should be globally available
 
 // Lastly import partials
+@import "partials/chessboard";

--- a/app/assets/stylesheets/partials/_chessboard.scss
+++ b/app/assets/stylesheets/partials/_chessboard.scss
@@ -1,39 +1,39 @@
 // This variable controls both the the height and width
 // of an individual chess square on the board.
-$board-space-size-std: 70px;
+$chessboard-space-size-std: 70px;
 
 // The board colors. Defaults are black and white, respectively.
-$board-space-dark: black;
-$board-space-lite: white;
+$chessboard-space-dark: black;
+$chessboard-space-lite: white;
 
 // Utility function to return width of one row on the board,
 // based on the fact that there are eight (8) squares to a row.
-@function total-board-width($board-square-width) {
-  @return $board-square-width * 8 + 2
+@function total-chessboard-width($chessboard-square-width) {
+  @return $chessboard-square-width * 8 + 2
 }
 
-.board {
-  width: total-board-width($board-space-size-std);
+.chessboard {
+  width:  total-chessboard-width($chessboard-space-size-std);
   margin: auto;
-  border: 1px solid $board-space-dark;
+  border: 1px solid $chessboard-space-dark;
 }
 
-.board_row {
-  clear: both;
+.chessboard__row {
+  clear:   both;
   display: table;
   content: "";
 }
 
-.board_space {
-  height: $board-space-size-std;
-  width: $board-space-size-std;
-  float: left;
+.chessboard__row__space {
+  height: $chessboard-space-size-std;
+  width:  $chessboard-space-size-std;
+  float:  left;
 }
 
-.dark {
-  background-color: $board-space-dark;
+.chessboard__row__space--dark {
+  background-color: $chessboard-space-dark;
 }
 
-.lite {
-  background-color: $board-space-lite;
+.chessboard__row__space--lite {
+  background-color: $chessboard-space-lite;
 }

--- a/app/assets/stylesheets/partials/_chessboard.scss
+++ b/app/assets/stylesheets/partials/_chessboard.scss
@@ -1,0 +1,39 @@
+// This variable controls both the the height and width
+// of an individual chess square on the board.
+$board-space-size-std: 70px;
+
+// The board colors. Defaults are black and white, respectively.
+$board-space-dark: black;
+$board-space-lite: white;
+
+// Utility function to return width of one row on the board,
+// based on the fact that there are eight (8) squares to a row.
+@function total-board-width($board-square-width) {
+  @return $board-square-width * 8 + 2
+}
+
+.board {
+  width: total-board-width($board-space-size-std);
+  margin: auto;
+  border: 1px solid $board-space-dark;
+}
+
+.board_row {
+  clear: both;
+  display: table;
+  content: "";
+}
+
+.board_space {
+  height: $board-space-size-std;
+  width: $board-space-size-std;
+  float: left;
+}
+
+.dark {
+  background-color: $board-space-dark;
+}
+
+.lite {
+  background-color: $board-space-lite;
+}

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,9 +1,33 @@
 <!-- Each view is contained with the outer layout and should begin with a row-->
 <div class="row">
   <div class="col-xs-12 col-md-8 col-md-offset-2">
-    <h1 class="text-primary">Show</h1>
-  </div>
-  <div class="col-xs-12 col-md-8 col-md-offset-2">
-    <a href="https://github.com/KnightsOfTheRemoteTable/chess_app">Github</a>
+
+    <!--Begin chessboard view -->
+    <div class="board">
+
+      <!-- A chessboard consists of eight (8) rows, starting (from the top)
+      with a lite-colored row. We can create eight (8) rows by creating
+      four (4) sets of lite-dark alternating rows -->
+      <% 4.times do %>
+
+      <!-- Create a row starting with the lite color -->
+        <div class="board_row">
+          <% 4.times do %>
+            <div class="lite board_space"></div>
+            <div class="dark board_space"></div>
+          <% end %>
+        </div>
+
+        <!-- Create a row starting with the dark color -->
+        <div class="board_row">
+          <% 4.times do %>
+            <div class="dark board_space"></div>
+            <div class="lite board_space"></div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+    <!--End chessboard view -->
+
   </div>
 </div>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -3,28 +3,31 @@
   <div class="col-xs-12 col-md-8 col-md-offset-2">
 
     <!--Begin chessboard view -->
-    <div class="board">
+    <div class="chessboard">
 
       <!-- A chessboard consists of eight (8) rows, starting (from the top)
       with a lite-colored row. We can create eight (8) rows by creating
       four (4) sets of lite-dark alternating rows -->
       <% 4.times do %>
 
-      <!-- Create a row starting with the lite color -->
-        <div class="board_row">
+      <!-- Create a row starting with the lite color, which we can do by
+      creating four (4) pairs of alternating squares, starting with lite-->
+        <div class="chessboard__row">
           <% 4.times do %>
-            <div class="lite board_space"></div>
-            <div class="dark board_space"></div>
+            <div class="chessboard__row__space chessboard__row__space--lite"></div>
+            <div class="chessboard__row__space chessboard__row__space--dark"></div>
           <% end %>
         </div>
 
-        <!-- Create a row starting with the dark color -->
-        <div class="board_row">
+        <!-- Create a row starting with the dark color, which we can do by
+        creating four (4) pairs of alternating squares, starting with dark-->
+        <div class="chessboard__row">
           <% 4.times do %>
-            <div class="dark board_space"></div>
-            <div class="lite board_space"></div>
+            <div class="chessboard__row__space chessboard__row__space--dark"></div>
+            <div class="chessboard__row__space chessboard__row__space--lite"></div>
           <% end %>
         </div>
+
       <% end %>
     </div>
     <!--End chessboard view -->


### PR DESCRIPTION
A few comments about this Pull Request that hopefully explain what I was trying to do.

* `main.scss` pulls in the chessboard partial, which does a number of things, including defining some styles that make the board work, as well as some variables that I pulled out that will make customization of the board easier down the road.

* I tried to keep the view file in `show.html.erb` as DRY as possible, but please let me know if, as we would say in the legal profession, what I did is "too cute by half". In other words, I would like the intent of the code to be consistent with Ruby's self-documenting approach - if the math is contorted or if you think there is an easier or more flexible way to do this, I am absolutely all ears!

:+1: :smile: 