### PR TITLE
Add rails_12factor gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,3 +55,7 @@ end
 group :test do
   gem 'capybara', '~> 2.5'
 end
+
+group :production do
+  gem 'rails_12factor'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,11 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.2)
       loofah (~> 2.0)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.4)
+    rails_stdout_logging (0.0.4)
     railties (4.2.4)
       actionpack (= 4.2.4)
       activesupport (= 4.2.4)
@@ -212,6 +217,7 @@ DEPENDENCIES
   jquery-rails
   pg
   rails (~> 4.2.4)
+  rails_12factor
   rspec-rails (~> 3.0)
   rubocop
   sass-rails (~> 5.0)


### PR DESCRIPTION
Adds support for log messages from heroku and configures rails to serve
static assets. See https://github.com/heroku/rails_12factor for more
details. Fixes #19 .