### PR TITLE
Update Gemfile to use SLIM

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,9 @@ gem 'rails', '~> 4.2.4'
 # Use postgresql as the database for Active Record
 gem 'pg'
 
+# Use SLIM for the front-end templating language
+gem 'slim-rails'
+
 # Use Bootstrap/SCSS for stylesheets
 gem 'bootstrap-sass', '~> 3.3.5'
 gem 'sass-rails',     '~> 5.0'


### PR DESCRIPTION
From now on, invoking `rails g` with anything that creates a view file should create a SLIM template by default. For more documentation on SLIM itself, please refer to http://slim-lang.com/