### PR TITLE
Increase max line length to 120

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
 Metrics/LineLength:
   Include:
     - 'app/**/*'
+  Max: 120
 
 Style/Documentation:
   Enabled: False


### PR DESCRIPTION
Rubocop's default of 80 is too restrictive.