### PR TITLE
Add obstructed? method

### DIFF
--- a/app/models/chess_piece.rb
+++ b/app/models/chess_piece.rb
@@ -11,41 +11,45 @@ class ChessPiece < ActiveRecord::Base
   enum color: [:black, :white]
 
   def obstructed?(destination_x, destination_y)
-    if diagonal_move?(destination_x, destination_y)
-      diagonal_obstruction?(destination_x, destination_y)
-    elsif vertical_move?(destination_x, destination_y)
-      vertical_obstruction?(destination_x, destination_y)
-    elsif horizontal_move?(destination_x, destination_y)
-      horizontal_obstruction?(destination_x, destination_y)
-    else
-      fail ArgumentError, 'Invalid move'
-    end
+    return diagonal_obstruction?(destination_x, destination_y) if diagonal_move?(destination_x, destination_y)
+    return vertical_obstruction?(destination_x, destination_y) if vertical_move?(destination_x, destination_y)
+    return horizontal_obstruction?(destination_x, destination_y) if horizontal_move?(destination_x, destination_y)
+    fail ArgumentError, 'Invalid move'
   end
 
   private
 
   def diagonal_obstruction?(destination_x, destination_y)
-    from_x, to_x = [position_x, destination_x].minmax
-    from_y = [position_y, destination_y].min
-    ((from_x + 1)...to_x).each_with_index do |x, idx|
-      return true if position_occupied?(x, from_y + idx + 1)
+    from_x = [position_x, destination_x].min + 1
+    from_y = [position_y, destination_y].min + 1
+    to_x = [position_x, destination_x].max
+
+    (from_x...to_x).each_with_index do |x, idx|
+      return true if position_occupied?(x, from_y + idx)
     end
+
     false
   end
 
   def vertical_obstruction?(destination_x, destination_y)
-    from_y, to_y = [position_y, destination_y].minmax
-    ((from_y + 1)...to_y).each do |y|
+    from_y = [position_y, destination_y].min + 1
+    to_y = [position_y, destination_y].max
+
+    (from_y...to_y).each do |y|
       return true if position_occupied?(destination_x, y)
     end
+
     false
   end
 
   def horizontal_obstruction?(destination_x, destination_y)
-    from_x, to_x = [position_x, destination_x].minmax
-    ((from_x + 1)...to_x).each do |x|
+    from_x = [position_x, destination_x].min + 1
+    to_x = [position_x, destination_x].max
+
+    (from_x...to_x).each do |x|
       return true if position_occupied?(x, destination_y)
     end
+
     false
   end
 
@@ -64,6 +68,7 @@ class ChessPiece < ActiveRecord::Base
   def diagonal_move?(destination_x, destination_y)
     x_diff = position_x - destination_x
     y_diff = position_y - destination_y
+
     x_diff.abs == y_diff.abs
   end
 end

--- a/app/models/chess_piece.rb
+++ b/app/models/chess_piece.rb
@@ -9,4 +9,61 @@ class ChessPiece < ActiveRecord::Base
             :color,
             presence: true
   enum color: [:black, :white]
+
+  def obstructed?(destination_x, destination_y)
+    if diagonal_move?(destination_x, destination_y)
+      diagonal_obstruction?(destination_x, destination_y)
+    elsif vertical_move?(destination_x, destination_y)
+      vertical_obstruction?(destination_x, destination_y)
+    elsif horizontal_move?(destination_x, destination_y)
+      horizontal_obstruction?(destination_x, destination_y)
+    else
+      fail ArgumentError, 'Invalid move'
+    end
+  end
+
+  private
+
+  def diagonal_obstruction?(destination_x, destination_y)
+    from_x, to_x = [position_x, destination_x].minmax
+    from_y = [position_y, destination_y].min
+    ((from_x + 1)...to_x).each_with_index do |x, idx|
+      return true if position_occupied?(x, from_y + idx + 1)
+    end
+    false
+  end
+
+  def vertical_obstruction?(destination_x, destination_y)
+    from_y, to_y = [position_y, destination_y].minmax
+    ((from_y + 1)...to_y).each do |y|
+      return true if position_occupied?(destination_x, y)
+    end
+    false
+  end
+
+  def horizontal_obstruction?(destination_x, destination_y)
+    from_x, to_x = [position_x, destination_x].minmax
+    ((from_x + 1)...to_x).each do |x|
+      return true if position_occupied?(x, destination_y)
+    end
+    false
+  end
+
+  def position_occupied?(x, y)
+    game.chess_pieces.where(position_x: x, position_y: y).present?
+  end
+
+  def horizontal_move?(destination_x, destination_y)
+    position_y == destination_y && position_x != destination_x
+  end
+
+  def vertical_move?(destination_x, destination_y)
+    position_x == destination_x && position_y != destination_y
+  end
+
+  def diagonal_move?(destination_x, destination_y)
+    x_diff = position_x - destination_x
+    y_diff = position_y - destination_y
+    x_diff.abs == y_diff.abs
+  end
 end

--- a/spec/models/chess_piece_spec.rb
+++ b/spec/models/chess_piece_spec.rb
@@ -15,4 +15,39 @@ RSpec.describe ChessPiece, type: :model do
   it { is_expected.to belong_to :game }
 
   it { is_expected.to define_enum_for :color }
+
+  describe '#obstructed?' do
+    let(:game) { create(:game) }
+    let(:king) { create(:king, position_x: 4, position_y: 1, game: game) }
+
+    describe 'invalid moves' do
+      it 'raises an error if move is not a straight line' do
+        expect { king.obstructed?(5, 3) }.to raise_error(ArgumentError)
+      end
+    end
+
+    describe 'vertical moves' do
+      it 'is true when a piece is in the way' do
+        create(:pawn, position_x: 4, position_y: 2, game: game)
+
+        expect(king.obstructed?(4, 3)).to eq true
+      end
+
+      it 'is false when unobstructed' do
+        expect(king.obstructed?(4, 3)).to eq false
+      end
+    end
+
+    describe 'horizontal moves' do
+      it 'is true when a piece is in the way' do
+        create(:pawn, position_x: 5, position_y: 1, game: game)
+
+        expect(king.obstructed?(6, 1)).to eq true
+      end
+
+      it 'is false when unobstructed' do
+        expect(king.obstructed?(6, 1)).to eq false
+      end
+    end
+  end
 end

--- a/spec/models/chess_piece_spec.rb
+++ b/spec/models/chess_piece_spec.rb
@@ -49,5 +49,17 @@ RSpec.describe ChessPiece, type: :model do
         expect(king.obstructed?(6, 1)).to eq false
       end
     end
+
+    describe 'diagonal moves' do
+      it 'is true when a piece is in the way' do
+        create(:pawn, position_x: 5, position_y: 2, game: game)
+
+        expect(king.obstructed?(6, 3)).to eq true
+      end
+
+      it 'is false when unobstructed' do
+        expect(king.obstructed?(6, 3)).to eq false
+      end
+    end
   end
 end


### PR DESCRIPTION
This method checks if any pieces are in the way of a move. The card says
it is supposed to be named is_obstructed? but rubocop doesn't like that.