### PR TITLE
Add spring gem for faster tdd

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ AllCops:
   RunRailsCops: true
   Exclude:
     - 'db/**/*'
+    - 'bin/**/*'
 Metrics/LineLength:
   Include:
     - 'app/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,10 @@ gem 'devise'
 group :development do
   # awesome_print gem for more readable output in terminal
   gem 'awesome_print'
+  # Use spring to preload the environent for faster tests
+  gem 'spring'
+  # Adds spring compatibility to rspec
+  gem 'spring-commands-rspec'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,6 +196,9 @@ GEM
       activesupport (>= 3.1, < 5.0)
       railties (>= 3.1, < 5.0)
       slim (~> 3.0)
+    spring (1.4.0)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     sprockets (3.4.0)
       rack (> 1, < 3)
     sprockets-rails (2.3.3)
@@ -242,5 +245,10 @@ DEPENDENCIES
   simple_form (~> 3.2)
   simplecov
   slim-rails
+  spring
+  spring-commands-rspec
   turbolinks
   uglifier (>= 1.3.0)
+
+BUNDLED WITH
+   1.10.6

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,8 @@
 #!/usr/bin/env ruby
+begin
+  load File.expand_path("../spring", __FILE__)
+rescue LoadError
+end
 APP_PATH = File.expand_path('../../config/application', __FILE__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/bin/rspec
+++ b/bin/rspec
@@ -3,6 +3,5 @@ begin
   load File.expand_path("../spring", __FILE__)
 rescue LoadError
 end
-require_relative '../config/boot'
-require 'rake'
-Rake.application.run
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')

--- a/bin/spring
+++ b/bin/spring
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+# This file loads spring without using Bundler, in order to be fast.
+# It gets overwritten when you run the `spring binstub` command.
+
+unless defined?(Spring)
+  require "rubygems"
+  require "bundler"
+
+  if (match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m))
+    Gem.paths = { "GEM_PATH" => [Bundler.bundle_path.to_s, *Gem.path].uniq }
+    gem "spring", match[1]
+    require "spring/binstub"
+  end
+end


### PR DESCRIPTION
The spring gem preloads the environment so your tests run much faster. It also makes loading the rails console much faster. This gem is included by default in newer versions of rails. It does have some side effects though, so if someone else doesn't like it, that is totally okay.