### PR TITLE
Eliminate simplecov redundancy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,8 +65,7 @@ group :test do
   # Use Capybara for acceptance testing
   gem 'capybara', '~> 2.5'
 
-  # Use simplecov for code coverage analysis
-  gem 'simplecov', require: false
+  # Use coveralls for code coverage analysis
   gem 'coveralls', require: false
 
   # Use shoulda-matchers for easy one-line tests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,7 +266,6 @@ DEPENDENCIES
   sdoc
   shoulda-matchers
   simple_form (~> 3.2)
-  simplecov
   slim-rails
   spring
   spring-commands-rspec


### PR DESCRIPTION
Simplecov is actually a dependency of the coveralls.io gem, so there is no need to separately list it in the `Gemfile` - anything and everything to reduce the size of the maintained code base, I would think!