### PR TITLE
Implement turn tracking

### DIFF
--- a/app/models/chess_piece.rb
+++ b/app/models/chess_piece.rb
@@ -30,6 +30,7 @@ class ChessPiece < ActiveRecord::Base
       destination_piece.destroy
     end
     update(position_x: destination_x, position_y: destination_y)
+    game.update_current_player!
   end
 
   def opposite_color

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -17,6 +17,7 @@ class Game < ActiveRecord::Base
     create_bishops
     create_rooks
     create_pawns
+    current_player_is_black_player!
   end
 
   def create_knights
@@ -63,6 +64,10 @@ class Game < ActiveRecord::Base
 
   def check?
     king_is_in_check?('black') || king_is_in_check?('white')
+  end
+
+  def update_current_player!
+    current_player_is_white_player? ? current_player_is_black_player! : current_player_is_white_player!
   end
 
   private

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -6,6 +6,9 @@ class Game < ActiveRecord::Base
 
   validates :name, presence: true
 
+  enum current_player: [:current_player_is_black_player,
+                        :current_player_is_white_player]
+
   after_create :populate_board!
 
   def populate_board!

--- a/db/migrate/20151127015904_add_current_player_to_game.rb
+++ b/db/migrate/20151127015904_add_current_player_to_game.rb
@@ -1,0 +1,5 @@
+class AddCurrentPlayerToGame < ActiveRecord::Migration
+  def change
+    add_column :games, :current_player, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151110190843) do
+ActiveRecord::Schema.define(version: 20151127015904) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,29 +31,30 @@ ActiveRecord::Schema.define(version: 20151110190843) do
   add_index "chess_pieces", ["player_id"], name: "index_chess_pieces_on_player_id", using: :btree
 
   create_table "games", force: :cascade do |t|
-    t.string   "name",            limit: 255
+    t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "white_player_id"
     t.integer  "black_player_id"
+    t.integer  "current_player"
   end
 
   add_index "games", ["black_player_id"], name: "index_games_on_black_player_id", using: :btree
   add_index "games", ["white_player_id"], name: "index_games_on_white_player_id", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  limit: 255, default: "", null: false
-    t.string   "encrypted_password",     limit: 255, default: "", null: false
-    t.string   "reset_password_token",   limit: 255
+    t.string   "email",                  default: "", null: false
+    t.string   "encrypted_password",     default: "", null: false
+    t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                      default: 0,  null: false
+    t.integer  "sign_in_count",          default: 0,  null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
     t.inet     "last_sign_in_ip"
-    t.datetime "created_at",                                      null: false
-    t.datetime "updated_at",                                      null: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
     t.string   "username"
   end
 

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -180,13 +180,13 @@ RSpec.describe Game do
 
     it 'when moved successfully, it switches the current player to white when black moves' do
       black_rook.move_to!(4, 5)
-      expect(black_rook.game.current_player_is_white_player?).to eq true
+      expect(game.current_player_is_white_player?).to eq true
     end
 
     it 'when moved successfully, it switches the current player to black when white moves' do
       game.current_player_is_white_player!
       white_rook.move_to!(7, 6)
-      expect(white_rook.game.current_player_is_black_player?).to eq true
+      expect(game.current_player_is_black_player?).to eq true
     end
   end
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -173,17 +173,22 @@ RSpec.describe Game do
       expect { black_rook.move_to!(6, 5) }.to raise_error(ArgumentError)
     end
 
-    it 'otherwise updates the current position of the piece' do
+    it 'otherwise updates the current x position of the piece' do
       black_rook.move_to!(4, 5)
       expect(black_rook.position_x).to eq 4
     end
 
-    it 'when moved successfully, it switches the current player to white when black moves' do
+    it 'otherwise updates the current y position of the piece' do
+      black_rook.move_to!(5, 6)
+      expect(black_rook.position_y).to eq 6
+    end
+
+    it 'when black moves, the current player becomes white' do
       black_rook.move_to!(4, 5)
       expect(game.current_player_is_white_player?).to eq true
     end
 
-    it 'when moved successfully, it switches the current player to black when white moves' do
+    it 'when white moves, the current player becomes black' do
       game.current_player_is_white_player!
       white_rook.move_to!(7, 6)
       expect(game.current_player_is_black_player?).to eq true

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -69,4 +69,50 @@ RSpec.describe Game do
       expect(game.check?).to eq true
     end
   end
+
+  describe '#current_player_is_black_player!' do
+    it 'sets the current player of the game to black' do
+      game = create(:game)
+      game.current_player_is_black_player!
+
+      expect(game.current_player_is_white_player?).to eq false
+      expect(game.current_player_is_black_player?).to eq true
+    end
+  end
+
+  describe '#current_player_is_black_player?' do
+    let(:game) { create(:game) }
+    it 'returns true if the current player of the game is the black player' do
+      game.current_player_is_black_player!
+      expect(game.current_player_is_black_player?).to eq true
+    end
+
+    it 'returns false otherwise' do
+      game.current_player_is_white_player!
+      expect(game.current_player_is_black_player?).to eq false
+    end
+  end
+
+  describe '#current_player_is_white_player!' do
+    it 'sets the current player of the game to white' do
+      game = create(:game)
+      game.current_player_is_white_player!
+
+      expect(game.current_player_is_black_player?).to eq false
+      expect(game.current_player_is_white_player?).to eq true
+    end
+  end
+
+  describe '#current_player_is_white_player?' do
+    let(:game) { create(:game) }
+    it 'returns true if the current player of the game is the white player' do
+      game.current_player_is_white_player!
+      expect(game.current_player_is_white_player?).to eq true
+    end
+
+    it 'returns false otherwise' do
+      game.current_player_is_black_player!
+      expect(game.current_player_is_white_player?).to eq false
+    end
+  end
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -11,6 +11,52 @@ RSpec.describe Game do
 
   it { is_expected.to validate_presence_of :name }
 
+  describe '#current_player_is_black_player!' do
+    it 'sets the current player of the game to black' do
+      game = create(:game)
+      game.current_player_is_black_player!
+
+      expect(game.current_player_is_white_player?).to eq false
+      expect(game.current_player_is_black_player?).to eq true
+    end
+  end
+
+  describe '#current_player_is_black_player?' do
+    let(:game) { create(:game) }
+    it 'returns true if the current player of the game is the black player' do
+      game.current_player_is_black_player!
+      expect(game.current_player_is_black_player?).to eq true
+    end
+
+    it 'returns false otherwise' do
+      game.current_player_is_white_player!
+      expect(game.current_player_is_black_player?).to eq false
+    end
+  end
+
+  describe '#current_player_is_white_player!' do
+    it 'sets the current player of the game to white' do
+      game = create(:game)
+      game.current_player_is_white_player!
+
+      expect(game.current_player_is_black_player?).to eq false
+      expect(game.current_player_is_white_player?).to eq true
+    end
+  end
+
+  describe '#current_player_is_white_player?' do
+    let(:game) { create(:game) }
+    it 'returns true if the current player of the game is the white player' do
+      game.current_player_is_white_player!
+      expect(game.current_player_is_white_player?).to eq true
+    end
+
+    it 'returns false otherwise' do
+      game.current_player_is_black_player!
+      expect(game.current_player_is_white_player?).to eq false
+    end
+  end
+
   describe 'games#populate_board!' do
     it 'initializes a Black & White King in correct starting position' do
       game = create(:game)
@@ -82,6 +128,7 @@ RSpec.describe Game do
 
   describe '#current_player_is_black_player?' do
     let(:game) { create(:game) }
+
     it 'returns true if the current player of the game is the black player' do
       game.current_player_is_black_player!
       expect(game.current_player_is_black_player?).to eq true
@@ -113,6 +160,33 @@ RSpec.describe Game do
     it 'returns false otherwise' do
       game.current_player_is_black_player!
       expect(game.current_player_is_white_player?).to eq false
+    end
+  end
+
+  describe '#move_to' do
+    let(:game) { create(:game) }
+    let(:black_rook) { create(:rook, color: 'black', game: game, position_x: 5, position_y: 5) }
+    let(:white_rook) { create(:rook, color: 'white', game: game, position_x: 6, position_y: 6) }
+
+    it 'generates an ArgumentError if a piece of the same color is at the destination' do
+      _occupying_rook = create(:rook, color: 'black', game: game, position_x: 6, position_y: 5)
+      expect { black_rook.move_to!(6, 5) }.to raise_error(ArgumentError)
+    end
+
+    it 'otherwise updates the current position of the piece' do
+      black_rook.move_to!(4, 5)
+      expect(black_rook.position_x).to eq 4
+    end
+
+    it 'when moved successfully, it switches the current player to white when black moves' do
+      black_rook.move_to!(4, 5)
+      expect(black_rook.game.current_player_is_white_player?).to eq true
+    end
+
+    it 'when moved successfully, it switches the current player to black when white moves' do
+      game.current_player_is_white_player!
+      white_rook.move_to!(7, 6)
+      expect(white_rook.game.current_player_is_black_player?).to eq true
     end
   end
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe Game do
     let(:white_rook) { create(:rook, color: 'white', game: game, position_x: 6, position_y: 6) }
 
     it 'generates an ArgumentError if a piece of the same color is at the destination' do
-      _occupying_rook = create(:rook, color: 'black', game: game, position_x: 6, position_y: 5)
+      create(:rook, color: 'black', game: game, position_x: 6, position_y: 5)
       expect { black_rook.move_to!(6, 5) }.to raise_error(ArgumentError)
     end
 

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Game do
 
   describe '#current_player_is_black_player?' do
     let(:game) { create(:game) }
+
     it 'returns true if the current player of the game is the black player' do
       game.current_player_is_black_player!
       expect(game.current_player_is_black_player?).to eq true


### PR DESCRIPTION
This simply uses an enum on the game model and the appropriate enum helpers. Runs through `#move_to!` as the trigger when the enum is set.