### PR TITLE
Enforce turn logic in the controller and fix bug with castling

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -1,6 +1,7 @@
 class PiecesController < ApplicationController
   before_action :authenticate_user!
   before_action :authorize_player
+  before_action :check_turn
 
   def show
     @chess_pieces = current_game.chess_pieces.order(:position_y).order(:position_x).to_a
@@ -27,6 +28,11 @@ class PiecesController < ApplicationController
   def authorize_player
     render text: 'Forbidden', status: :unauthorized unless
       current_user == current_game.send("#{selected_piece.color}_player")
+  end
+
+  def check_turn
+    render text: 'Not your turn', status: :forbidden unless
+      current_game.send("current_player_is_#{selected_piece.color}_player?")
   end
 
   def current_game

--- a/app/models/chess_piece.rb
+++ b/app/models/chess_piece.rb
@@ -25,7 +25,7 @@ class ChessPiece < ActiveRecord::Base
 
     update(position_x: coordinates.x, position_y: coordinates.y)
     game.update(en_passant_position: nil)
-    game.update_current_player!
+    game.update_current_player!(color)
   end
 
   def opposite_color

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -32,7 +32,7 @@ class Game < ActiveRecord::Base
     create_bishops
     create_rooks
     create_pawns
-    current_player_is_black_player!
+    current_player_is_white_player!
   end
 
   def create_knights
@@ -81,8 +81,8 @@ class Game < ActiveRecord::Base
     king_is_in_check?('black') || king_is_in_check?('white')
   end
 
-  def update_current_player!
-    current_player_is_white_player? ? current_player_is_black_player! : current_player_is_white_player!
+  def update_current_player!(color)
+    color == 'white' ? current_player_is_black_player! : current_player_is_white_player!
   end
 
   def can_en_passant?(coordinates)


### PR DESCRIPTION
Since castling involves 2 moves and the turn logic toggled the current
player on every move it broke. Now we just sent the current player to
the opposite color of the last piece moved. Also add a before_action to
the pieces controller with keeps players from moving when not their
turn.