### PR TITLE
Pusher fix

### DIFF
--- a/app/assets/javascripts/games.js.coffee
+++ b/app/assets/javascripts/games.js.coffee
@@ -1,12 +1,12 @@
 
 $ ->
-
   gameId = $('.chessboard').data('channelid')
-  pusher = new Pusher '9d04d520abd8261569ea', { encrypted: true }
-  channel = pusher.subscribe gameId
 
-  channel.bind 'refresh_event', (data)->
-    location.reload()
+  if (gameId != undefined)
+    pusher = new Pusher '9d04d520abd8261569ea', { encrypted: true }
+    channel = pusher.subscribe gameId
+    channel.bind 'refresh_event', (data)->
+      location.reload()
 
   $('.chessboard__row__space a').draggable
     cursor: 'move',

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -56,7 +56,7 @@ class PiecesController < ApplicationController
   def attempt_move
     return unless moving_validly?
     selected_piece.move_to!(destination_coordinates)
-    Pusher.trigger(current_game.id, 'refresh_event', message: '') unless Rails.env.test?
+    Pusher.trigger("channel-#{current_game.id}", 'refresh_event', message: '') unless Rails.env.test?
   end
 
   def successful_move?

--- a/app/views/games/show.html.slim
+++ b/app/views/games/show.html.slim
@@ -3,7 +3,7 @@
   .col-xs-12.col-md-8.col-md-offset-2
 
     /Begin chessboard view
-    .chessboard data-channelid="#{@game.id}"
+    .chessboard data-channelid="channel-#{@game.id}"
       / A chessboard consists of eight (8) rows, starting (from the top)
       / with a lite-colored row. We can create eight (8) rows by creating
       / four (4) sets of lite-dark alternating rows


### PR DESCRIPTION
This hopefully addresses #86 by doing two things:

* It replaces the channel name from simply `id` (where that is an integer representing the `game_id`) to `channel-id`, so that there is leading text, which appears to fix one issue.

* It encases the entire subscription logic in an if block such that it only runs when you are on the `Game#show` page (because that is the only page that writes out the value we are checking for in the if block). 