### PR TITLE
Update games#index to not include forfeited games

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -3,7 +3,7 @@ class GamesController < ApplicationController
   before_action :authorize_player, only: :forfeit
 
   def index
-    @games = Game.all
+    @games = Game.where(winner: nil)
   end
 
   def new
@@ -37,7 +37,7 @@ class GamesController < ApplicationController
 
   def forfeit
     current_game.forfeit_by!(current_user)
-    redirect_to current_game, alert: 'You have forfeited the game'
+    redirect_to games_path, alert: 'You have forfeited the game'
   end
 
   private

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -3,7 +3,7 @@ class GamesController < ApplicationController
   before_action :authorize_player, only: :forfeit
 
   def index
-    @games = Game.where(winner: nil)
+    @games = Game.active
   end
 
   def new

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -10,6 +10,8 @@ class Game < ActiveRecord::Base
   enum current_player: [:current_player_is_black_player,
                         :current_player_is_white_player]
 
+  scope :active, -> { where(winner: nil) }
+
   after_create :populate_board!
 
   def forfeit_by!(player)

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe GamesController, type: :controller do
 
       put :forfeit, id: game
 
-      expect(response).to redirect_to game
+      expect(response).to redirect_to games_path
       expect(game.reload.winner).to eq white_player
     end
 


### PR DESCRIPTION
This patches #93 and additionally changes the `#forfeit` action to re-direct to the main games page after a forfeit.