### PR TITLE
Fix google oauth

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -9,7 +9,7 @@ module Users
       redirect_to new_user_registration_url
     end
 
-    def google_oauth2
+    def google
       @user = User.from_omniauth(request.env['omniauth.auth'])
 
       return sign_in_and_prompt_for_username(@user, 'Google') if @user.persisted?
@@ -24,7 +24,7 @@ module Users
       sign_in user, event: :authentication
       set_flash_message(:notice, :success, kind: provider) if is_navigational_format?
       if user.username == user.uid
-        redirect_to username_path
+        redirect_to user_username_path
       else
         redirect_to root_path
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable,
-         :omniauthable, omniauth_providers: [:facebook, :google_oauth2]
+         :omniauthable, omniauth_providers: [:facebook, :google]
   validates :username, presence: true
 
   def self.from_omniauth(auth)

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -263,5 +263,5 @@ Devise.setup do |config|
   # config.omniauth_path_prefix = '/my_engine/users/auth'
 
   config.omniauth :facebook, ENV.fetch('FACEBOOK_CLIENT_ID'), ENV.fetch('FACEBOOK_CLIENT_SECRET')
-  config.omniauth :google_oauth2, ENV.fetch('GOOGLE_CLIENT_ID'), ENV.fetch('GOOGLE_CLIENT_SECRET')
+  config.omniauth :google_oauth2, ENV.fetch('GOOGLE_CLIENT_ID'), ENV.fetch('GOOGLE_CLIENT_SECRET'), name: :google
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -261,8 +261,7 @@ Devise.setup do |config|
   # When using OmniAuth, Devise cannot automatically set OmniAuth path,
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = '/my_engine/users/auth'
-  OmniAuth.config.full_host = Rails.env.production? ? 'https://chess-application.herokuapp.com' : 'http://localhost:3000'
-  CALLBACK_URL = 'http://localhost:3000/users/auth/google_oauth2/callback'
-  config.omniauth :facebook, ENV['FACEBOOK_CLIENT_ID'], ENV['FACEBOOK_CLIENT_SECRET']
-  config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET']
+
+  config.omniauth :facebook, ENV.fetch('FACEBOOK_CLIENT_ID'), ENV.fetch('FACEBOOK_CLIENT_SECRET')
+  config.omniauth :google_oauth2, ENV.fetch('GOOGLE_CLIENT_ID'), ENV.fetch('GOOGLE_CLIENT_SECRET')
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,9 +4,9 @@ ChessApp::Application.routes.draw do
   resources :pieces, only: [:show, :update] do
     get 'valid_moves', on: :member
   end
-  get '/username', to: 'users#username'
-  resources :users, only: :show
-  resource :user, only: :update
+  resources :users, only: [:show, :update] do
+    get '/username', to: 'users#username'
+  end
   resources :games, only: [:index, :new, :create, :show] do
     put 'forfeit', on: :member
     put 'join', on: :member


### PR DESCRIPTION
This does 2 things:

- Uses ENV.fetch to get the env variables so it fails if they are missing
- Override the provider name to be google instead of google_oauth2