### PR TITLE
Remove username

### DIFF
--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -16,8 +16,6 @@ nav.navbar.navbar-default
           li
             = gravatar_for current_user
           li
-            = link_to current_user.username, "#"
-          li
             = link_to "Sign Out", destroy_user_session_path, method: :delete
         - else
           li


### PR DESCRIPTION
We're not currently doing anything with the username, so it seems like we should remove the dead link.