### PR TITLE
Add support for promoting pawns

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -23,6 +23,12 @@ class PiecesController < ApplicationController
     render json: selected_piece.valid_moves
   end
 
+  def promote
+    render(text: 'Piece is not promotable', status: :forbidden) && return unless selected_piece.promotable?
+    selected_piece.promote_to!(params[:type])
+    redirect_to current_game
+  end
+
   private
 
   def authorize_player

--- a/app/models/chess_piece.rb
+++ b/app/models/chess_piece.rb
@@ -77,6 +77,10 @@ class ChessPiece < ActiveRecord::Base
     potential_moves
   end
 
+  def promotable?
+    false
+  end
+
   private
 
   def move_for(coordinates)

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -17,6 +17,11 @@ class Pawn < ChessPiece
     capture_en_passant(coordinates) if game.can_en_passant?(coordinates)
     super
     game.update(en_passant_position: "#{coordinates.x},#{backward_one(coordinates.y)}") if two_step_move
+    game.update_current_player!(opposite_color)
+  end
+
+  def promotable?
+    position_y == 8 || position_y == 1
   end
 
   private

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -16,15 +16,24 @@ class Pawn < ChessPiece
     two_step_move = diff_in_y(coordinates.y) == FIRST_MOVE_FACTOR
     capture_en_passant(coordinates) if game.can_en_passant?(coordinates)
     super
-    game.update(en_passant_position: "#{coordinates.x},#{backward_one(coordinates.y)}") if two_step_move
-    game.update_current_player!(opposite_color)
+    update_en_passant(coordinates) if two_step_move
+    game.update_current_player!(opposite_color) if promotable?
   end
 
   def promotable?
     position_y == 8 || position_y == 1
   end
 
+  def promote_to!(type)
+    update(type: type)
+    game.update_current_player!(color)
+  end
+
   private
+
+  def update_en_passant(coordinates)
+    game.update(en_passant_position: "#{coordinates.x},#{backward_one(coordinates.y)}")
+  end
 
   def capture_en_passant(coordinates)
     game.chess_pieces.find_by(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,10 @@ ChessApp::Application.routes.draw do
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
   root 'static_pages#index'
   resources :pieces, only: [:show, :update] do
-    get 'valid_moves', on: :member
+    member do
+      get 'valid_moves'
+      put 'promote'
+    end
   end
   resources :users, only: [:show, :update] do
     get '/username', to: 'users#username'

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -112,4 +112,14 @@ RSpec.describe Pawn do
       expect(pawn.promotable?).to eq true
     end
   end
+
+  describe '#promote_to!' do
+    it 'promotes the pawn to the specified type' do
+      pawn = build(:pawn, position_x: 1, position_y: 8)
+
+      pawn.promote_to!('Queen')
+
+      expect(pawn.type).to eq 'Queen'
+    end
+  end
 end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -98,4 +98,18 @@ RSpec.describe Pawn do
       expect(Pawn.find_by(id: pawn.id)).to be_nil
     end
   end
+
+  describe '#promotable?' do
+    it 'is false when not in rank 1 or 8' do
+      pawn = build(:pawn, position_x: 1, position_y: 4)
+
+      expect(pawn.promotable?).to eq false
+    end
+
+    it 'is true when promotion is available' do
+      pawn = build(:pawn, position_x: 1, position_y: 8)
+
+      expect(pawn.promotable?).to eq true
+    end
+  end
 end


### PR DESCRIPTION
# WIP :construction: 

This adds support for promoting pawns when they reach the opposite home rank. Backend is finished, just need to add frontend support.