### PR TITLE
Remove page refresh after move

### DIFF
--- a/app/assets/javascripts/games.js.coffee
+++ b/app/assets/javascripts/games.js.coffee
@@ -1,17 +1,4 @@
 $ ->
-  gameId = $('.chessboard').data('channelid')
-
-  if (gameId != undefined)
-    pusher = new Pusher '9d04d520abd8261569ea', { encrypted: true }
-    channel = pusher.subscribe gameId
-    channel.bind 'move', (data)->
-      piece = $("[data-id=#{data.piece_id}]")
-
-      if piece.css('top') == '0px' && piece.css('left') == '0px'
-        animateMove(piece, data.destination)
-      else
-        movePieceElement(piece, data.destination)
-
   $('#myModal').on 'show.bs.modal', (e)->
     $('.modal-body').html('<h4>Loading...</h4>')
     userId = $(e.relatedTarget).data('playerid')
@@ -19,12 +6,12 @@ $ ->
     $.get url, (response)->
       html = '<img src=' + response.gravatar_url + '></img><h4>' + response.name + ' has been registered since ' + response.playing_since + ' and has ' + response.total_wins + ' total wins.' + '</h4>'
       $('.modal-body').html(html)
-
   $('.chessboard__row__space a').draggable
     cursor: 'move',
     snap: '.chessboard__row__space',
     snapMode: 'inner',
     revert: 'invalid',
+    zIndex: 5,
     start: (event, ui)->
       url = ui.helper.attr('href') + '/valid_moves'
       $.get url, (response)->
@@ -49,14 +36,3 @@ $ ->
           position_y: $target.data('y')
       error: (response)->
         ui.draggable.animate(top: 0, left: 0)
-
-movePieceElement = (piece, destination)->
-  piece.css(top: 0, left: 0)
-  destinationSquare = $("[data-x=#{destination.x}][data-y=#{destination.y}]")
-  destinationSquare.empty().append(piece.detach())
-
-animateMove = (piece, destination)->
-  topOffset = (destination.y - piece.parent().data('y')) * 72
-  leftOffset = (destination.x - piece.parent().data('x')) * 72
-  piece.animate top: topOffset, left: leftOffset, ->
-    movePieceElement(piece, destination)

--- a/app/assets/javascripts/games.js.coffee
+++ b/app/assets/javascripts/games.js.coffee
@@ -1,12 +1,16 @@
-
 $ ->
   gameId = $('.chessboard').data('channelid')
 
   if (gameId != undefined)
     pusher = new Pusher '9d04d520abd8261569ea', { encrypted: true }
     channel = pusher.subscribe gameId
-    channel.bind 'refresh_event', (data)->
-      location.reload()
+    channel.bind 'move', (data)->
+      piece = $("[data-id=#{data.piece_id}]")
+
+      if piece.css('top') == '0px' && piece.css('left') == '0px'
+        animateMove(piece, data.destination)
+      else
+        movePieceElement(piece, data.destination)
 
   $('#myModal').on 'show.bs.modal', (e)->
     $('.modal-body').html('<h4>Loading...</h4>')
@@ -43,8 +47,16 @@ $ ->
         piece:
           position_x: $target.data('x'),
           position_y: $target.data('y')
-      success: ->
-        piece.css(top: 0, left: 0)
-        $target.empty().append(piece.detach())
       error: (response)->
         ui.draggable.animate(top: 0, left: 0)
+
+movePieceElement = (piece, destination)->
+  piece.css(top: 0, left: 0)
+  destinationSquare = $("[data-x=#{destination.x}][data-y=#{destination.y}]")
+  destinationSquare.empty().append(piece.detach())
+
+animateMove = (piece, destination)->
+  topOffset = (destination.y - piece.parent().data('y')) * 72
+  leftOffset = (destination.x - piece.parent().data('x')) * 72
+  piece.animate top: topOffset, left: leftOffset, ->
+    movePieceElement(piece, destination)

--- a/app/assets/javascripts/pusher.coffee
+++ b/app/assets/javascripts/pusher.coffee
@@ -1,0 +1,28 @@
+$ ->
+  gameId = $('.chessboard').data('channelid')
+
+  if (gameId != undefined)
+    pusher = new Pusher '9d04d520abd8261569ea', { encrypted: true }
+    channel = pusher.subscribe gameId
+    channel.bind 'move', (data)->
+      piece = $("[data-id=#{data.piece_id}]")
+
+      if piece.css('top') == '0px' && piece.css('left') == '0px'
+        animateMove(piece, data.destination)
+      else
+        movePieceElement(piece, data.destination)
+
+    channel.bind 'status', (data)->
+      $('.status').text(data.message)
+
+movePieceElement = (piece, destination)->
+  piece.css(top: 0, left: 0)
+  destinationSquare = $("[data-x=#{destination.x}][data-y=#{destination.y}]")
+  destinationSquare.empty().append(piece.detach())
+
+animateMove = (piece, destination)->
+  topOffset = (destination.y - piece.parent().data('y')) * 72
+  leftOffset = (destination.x - piece.parent().data('x')) * 72
+  piece.animate top: topOffset, left: leftOffset, ->
+    movePieceElement(piece, destination)
+

--- a/app/assets/stylesheets/partials/_chessboard.scss
+++ b/app/assets/stylesheets/partials/_chessboard.scss
@@ -42,6 +42,9 @@ $chessboard-border: #8A6B3D;
   }
 
   a {
+    position: relative;
+    left: 0;
+    top: 0;
     width: 100%;
   }
 }

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -57,7 +57,7 @@ class PiecesController < ApplicationController
     return unless moving_validly?
     selected_piece.move_to!(destination_coordinates)
     check_game_over
-    push_move unless Rails.env.test?
+    push_move && push_status unless Rails.env.test?
   end
 
   def push_move
@@ -69,6 +69,16 @@ class PiecesController < ApplicationController
         x: destination_coordinates.x,
         y: destination_coordinates.y
       }
+    )
+  end
+
+  def push_status
+    color = selected_piece.opposite_color
+    Pusher.trigger(
+      "channel-#{current_game.id}",
+      'status',
+      message: "It is #{color}'s turn."\
+        "#{color.capitalize} is being played by #{current_game.send("#{color}_player").username}"
     )
   end
 

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -57,7 +57,19 @@ class PiecesController < ApplicationController
     return unless moving_validly?
     selected_piece.move_to!(destination_coordinates)
     check_game_over
-    Pusher.trigger("channel-#{current_game.id}", 'refresh_event', message: '') unless Rails.env.test?
+    push_move unless Rails.env.test?
+  end
+
+  def push_move
+    Pusher.trigger(
+      "channel-#{current_game.id}",
+      'move',
+      piece_id: selected_piece.id,
+      destination: {
+        x: destination_coordinates.x,
+        y: destination_coordinates.y
+      }
+    )
   end
 
   def check_game_over

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -13,7 +13,7 @@ module GamesHelper
     return unless current_piece
 
     link_to image_tag("#{current_piece.color.downcase}_#{current_piece.type.downcase}.png"),
-            piece_path(current_piece)
+            piece_path(current_piece), data: { id: current_piece.id }
   end
 
   def current_user_can_forfeit?(game)


### PR DESCRIPTION
This pushes json down to the client which is used to update the board
client-side. Still need to add support for status messages as well as
special moves (castling, en passant, pawn promotion, etc.)
